### PR TITLE
fix 100vh in mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "react": "^17.0.2",
+    "react-div-100vh": "^0.6.0",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { LngLatBounds, Map, IControl } from "mapbox-gl";
 import GeoloniaMap from "./GeoloniaMap";
 import ReactDOM from "react-dom";
 import { FeatureCollection, GeoJsonProperties, Geometry } from "geojson";
+import Div100vh from 'react-div-100vh'
 
 interface SearchFormControlsCollection extends HTMLFormControlsCollection {
   q: HTMLInputElement
@@ -284,22 +285,24 @@ const App: React.FC = () => {
 
   return (
     <>
-      <GeoloniaMap
-        style={{ width: "100vw", height: "100vh" }}
-        options={{
-          "data-zoom": savedState.z,
-          "data-lng": savedState.lng,
-          "data-lat": savedState.lat,
-          "data-fullscreen-control": "on",
-          "data-geolocate-control": "on",
-          "data-gesture-handling": "off",
-          "data-marker": "off",
-          "data-3d": "on",
-          "data-scale-control": "bottom-right",
-          "data-style": defaultStyleUrl,
-        }}
-        onLoad={onLoad}
-      />
+      <Div100vh>
+        <GeoloniaMap
+          style={{ width: "100vw", height: "100%"}}
+          options={{
+            "data-zoom": savedState.z,
+            "data-lng": savedState.lng,
+            "data-lat": savedState.lat,
+            "data-fullscreen-control": "on",
+            "data-geolocate-control": "on",
+            "data-gesture-handling": "off",
+            "data-marker": "off",
+            "data-3d": "on",
+            "data-scale-control": "bottom-right",
+            "data-style": defaultStyleUrl,
+          }}
+          onLoad={onLoad}
+        />
+      </Div100vh>
       <Portal container={switcherControlDiv}>
         <select
           onChange={onMapStyleChange}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9322,6 +9322,11 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
+react-div-100vh@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-div-100vh/-/react-div-100vh-0.6.0.tgz#577972d8ac17693edcd44061c1a4b5a7578e49ec"
+  integrity sha512-ErV0VTNXUd8jZqofC0ExZr5u+XDD2kN2te4SbwtqsyTm0UOjVYu53kP+FalGQrTe+DoMG8VYR2dITcAFu7c/5w==
+
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"


### PR DESCRIPTION
モバイルで表示時に、ツールバーでコピーライトなどが消える問題を修正しました。

![IMG_40B89D9C023A-1](https://user-images.githubusercontent.com/8760841/132120772-1a9546fe-eacb-4aa2-badd-95cbf5440888.jpeg)
