### PR TITLE
change cdn to cdn.geolonia.com

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script id="geolonia-embed" async src="https://cdn.geoloniamaps.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
+    <script id="geolonia-embed" async src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
     <title>Geolonia Maps</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -320,7 +320,7 @@ const App: React.FC = () => {
         <GeoloniaMap
           style={{ width: '100vw', height: '100%' }}
           initOptions={{ hash: 'map' }}
-          embedSrc="https://cdn.geoloniamaps.com/dev/embed?geolonia-api-key=YOUR-API-KEY"
+          embedSrc="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"
           fullscreenControl="on"
           geolocateControl="on"
           gestureHandling="off"


### PR DESCRIPTION
CDN を cdn.geoloniamaps.com から、cdn.geolonia.com に変更しました。