### PR TITLE
Use normalize any latlng

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@geolonia/embed-react": "^1.2.2",
+    "@geolonia/normalize-any-latlng": "^0.0.2",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,11 @@
     eslint-plugin-react "^7.25.1"
     typescript "^4.4.2"
 
+"@geolonia/normalize-any-latlng@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@geolonia/normalize-any-latlng/-/normalize-any-latlng-0.0.2.tgz#a086711840bf9757f23960b23119dcccf0f05a06"
+  integrity sha512-+MwlLE3IC2s707Jb+1xYS4oAB1Z+Ot7vmdo4Qxeu9hPZRq2yTdQYnw/oDUyB4cIVaphUlMZU42aw0UOpp3xrvw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"


### PR DESCRIPTION
@geolonia/normalize-any-latlng を使ってクエリが緯度経度だと判定されたらその結果を、そうでなければ従来通り https://api.maps.geolonia.com へリクエストするように変更しました。

[`北緯32度53分9.35秒 東経130度11分9.34秒`](https://geohack.toolforge.org/geohack.php?language=ja&pagename=%E8%AB%AB%E6%97%A9%E6%B9%BE&params=32_53_9.35_N_130_11_9.34_E_type:waterbody_region:JP) のクエリ結果:
![スクリーンショット 2023-08-28 15 08 16](https://github.com/geolonia/maps.geolonia.com/assets/6292312/179f82ec-0a9d-4dab-b538-81e8b88b4750)
