### PR TITLE
スタイル選択メニューから Basic v1 と Basic (Legacy) を削除

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -377,8 +377,6 @@ const App: React.FC = () => {
             >
               <optgroup label="標準スタイル">
                 <option value="geolonia/basic-v2">Basic v2</option>
-                <option value="geolonia/basic-v1">Basic v1</option>
-                <option value="geolonia/basic">Basic (Legacy)</option>
                 <option value="geolonia/gsi">GSI</option>
                 <option value="geolonia/homework">Homework</option>
                 <option value="geolonia/midnight">Midnight</option>


### PR DESCRIPTION
## 概要

スタイル選択メニューの「標準スタイル」から、以下 2 件の選択肢を削除しました。

- `geolonia/basic-v1` (Basic v1)
- `geolonia/basic` (Basic (Legacy))

現行の標準スタイルは Basic v2 です。このデモページの初期スタイルもすでに `geolonia/basic-v2` になっているため、旧バージョンを並べて提示する必要がなくなりました。

## 変更内容

`src/App.tsx` の `<optgroup label="標準スタイル">` から該当する `<option>` を 2 行削除しただけの変更です。ロジックの変更はありません。

## 影響

- 初期表示は従来どおり Basic v2 です。
- URL の hash や localStorage に旧スタイル ID が入っている場合、地図自体はそのスタイルで描画されますが、セレクトボックス上では選択済みとして表示されません。切り替え操作を 1 回行えば通常の状態に戻ります。

## 確認したこと

- `yarn run lint` 成功
- `yarn run build` 成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * スタイル選択画面から、旧「geolonia/basic-v1」と「geolonia/basic」を削除しました。
  * 「geolonia/basic-v2」を標準スタイルの先頭に表示するよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->